### PR TITLE
fix(plugin.xml): MSB-5871 - package visibility for OEMInfo

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,15 +38,18 @@
     <platform name="android">
         <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
         <framework src="com.github.ltrudu:DeviceIdentifiersWrapper:0.2" />
-        
+
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="Device" >
                 <param name="android-package" value="org.apache.cordova.device.Device"/>
             </feature>
         </config-file>
         <config-file parent="/manifest" target="AndroidManifest.xml">
-           <uses-permission android:name="com.zebra.provider.READ" />
-           <uses-permission android:name="com.symbol.emdk.permission.EMDK" />
+            <uses-permission android:name="com.zebra.provider.READ" />
+            <uses-permission android:name="com.symbol.emdk.permission.EMDK" />
+            <queries>
+                <package android:name="com.zebra.zebracontentprovider" />
+            </queries>
          </config-file>
          <config-file parent="/manifest/application" target="AndroidManifest.xml">
            <uses-library android:name="com.symbol.emdk" android:required="false" />


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Due to Android 11 Package Visibility we don't have access to Zebra's OEMInfo.
See https://techdocs.zebra.com/bestpractices/migration/android11/



